### PR TITLE
Allow subscribing and unsubscribing by CSV 

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -69,9 +69,11 @@ func Run(ctx context.Context, logger zerolog.Logger, store db.Store) {
 	app.Delete("/v1/webhooks/:webhookId", jwtMiddleware, webhookController.DeleteWebhook)
 
 	// Vehicle subscriptions
+	app.Post("/v1/webhooks/:webhookId/subscribe/csv", jwtMiddleware, vehicleSubscriptionController.SubscribeVehiclesFromCSV)
 	app.Post("/v1/webhooks/:webhookId/subscribe/all", jwtMiddleware, vehicleSubscriptionController.SubscribeAllVehiclesToWebhook)
-	app.Delete("/v1/webhooks/:webhookId/unsubscribe/all", jwtMiddleware, vehicleSubscriptionController.UnsubscribeAllVehiclesFromWebhook)
 	app.Post("/v1/webhooks/:webhookId/subscribe/:vehicleTokenId", jwtMiddleware, vehicleSubscriptionController.AssignVehicleToWebhook)
+	app.Delete("/v1/webhooks/:webhookId/unsubscribe/csv", jwtMiddleware, vehicleSubscriptionController.UnsubscribeVehiclesFromCSV)
+	app.Delete("/v1/webhooks/:webhookId/unsubscribe/all", jwtMiddleware, vehicleSubscriptionController.UnsubscribeAllVehiclesFromWebhook)
 	app.Delete("/v1/webhooks/:webhookId/unsubscribe/:vehicleTokenId", jwtMiddleware, vehicleSubscriptionController.RemoveVehicleFromWebhook)
 	app.Get("/v1/webhooks/vehicles/:vehicleTokenId", jwtMiddleware, vehicleSubscriptionController.ListSubscriptions)
 

--- a/internal/controllers/vehicle_subscription_controller.go
+++ b/internal/controllers/vehicle_subscription_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/csv"
 	"fmt"
 	"net/http"
 	"time"
@@ -83,6 +84,158 @@ func (v *VehicleSubscriptionController) AssignVehicleToWebhook(c *fiber.Ctx) err
 		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to assign vehicle"})
 	}
 	return c.Status(http.StatusCreated).JSON(fiber.Map{"message": "Vehicle assigned successfully"})
+}
+
+// SubscribeVehiclesFromCSV godoc
+// @Summary      Assign multiple vehicles to a webhook from CSV
+// @Description  Parses a CSV file from the request body and subscribes each vehicleTokenId to the webhook.
+// @Tags         Webhooks
+// @Accept       text/csv
+// @Produce      json
+// @Param        webhookId  path  string  true  "Webhook ID"
+// @Success      201        {object}  map[string]string  "Count of subscribed vehicles"
+// @Failure      400        {object}  map[string]string  "Bad request"
+// @Failure      401        {object}  map[string]string  "Unauthorized"
+// @Failure      500        {object}  map[string]string  "Internal server error"
+// @Security     BearerAuth
+// @Router       /v1/webhooks/{webhookId}/subscribe/csv [post]
+func (v *VehicleSubscriptionController) SubscribeVehiclesFromCSV(c *fiber.Ctx) error {
+	webhookID := c.Params("webhookId")
+	dl, err := getDevLicense(c, v.logger)
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to get file from form data")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Missing CSV file"})
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to open uploaded file")
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to open CSV file"})
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to parse CSV")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Invalid CSV format"})
+	}
+
+	if len(records) == 0 || len(records[0]) == 0 || records[0][0] != "tokenId" {
+		v.logger.Error().Msg("CSV header missing or invalid")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "CSV header must contain 'tokenId'"})
+	}
+
+	var count int
+	for _, record := range records[1:] {
+		if len(record) == 0 {
+			continue
+		}
+		tokenStr := record[0]
+		if _, err := decimal.NewFromString(tokenStr); err != nil {
+			v.logger.Error().Err(err).Msgf("Invalid token format in CSV: %v", tokenStr)
+			continue
+		}
+		dec := types.Decimal{}
+		if err := dec.Scan(tokenStr); err != nil {
+			v.logger.Error().Err(err).Msgf("Invalid token format in CSV: %v", tokenStr)
+			continue
+		}
+
+		ev := &models.EventVehicle{
+			VehicleTokenID:          dec,
+			EventID:                 webhookID,
+			DeveloperLicenseAddress: dl,
+			CreatedAt:               time.Now(),
+			UpdatedAt:               time.Now(),
+		}
+		if err := ev.Insert(c.Context(), v.store.DBS().Writer, boil.Infer()); err != nil {
+			v.logger.Error().Err(err).Msgf("Failed to assign vehicle from CSV: %v", tokenStr)
+			continue
+		}
+		count++
+	}
+
+	return c.Status(http.StatusCreated).JSON(fiber.Map{"message": fmt.Sprintf("Subscribed %d vehicles", count)})
+}
+
+// UnsubscribeVehiclesFromCSV godoc
+// @Summary      Unsubscribe multiple vehicles from a webhook using CSV
+// @Description  Parses a CSV file from the request body and unsubscribes each vehicleTokenId from the webhook.
+// @Tags         Webhooks
+// @Accept       text/csv
+// @Produce      json
+// @Param        webhookId  path  string  true  "Webhook ID"
+// @Success      200        {object}  map[string]string  "Count of unsubscribed vehicles"
+// @Failure      400        {object}  map[string]string  "Bad request"
+// @Failure      401        {object}  map[string]string  "Unauthorized"
+// @Failure      500        {object}  map[string]string  "Internal server error"
+// @Security     BearerAuth
+// @Router       /v1/webhooks/{webhookId}/unsubscribe/csv [delete]
+func (v *VehicleSubscriptionController) UnsubscribeVehiclesFromCSV(c *fiber.Ctx) error {
+	webhookID := c.Params("webhookId")
+	dl, err := getDevLicense(c, v.logger)
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to get file from form data")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Missing CSV file"})
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to open uploaded file")
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to open CSV file"})
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		v.logger.Error().Err(err).Msg("Failed to parse CSV")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Invalid CSV format"})
+	}
+
+	if len(records) == 0 || len(records[0]) == 0 || records[0][0] != "tokenId" {
+		v.logger.Error().Msg("CSV header missing or invalid")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "CSV header must contain 'tokenId'"})
+	}
+
+	var count int
+	for _, record := range records[1:] {
+		if len(record) == 0 {
+			continue
+		}
+		tokenStr := record[0]
+		dec := types.Decimal{}
+		if err := dec.Scan(tokenStr); err != nil {
+			v.logger.Error().Err(err).Msgf("Invalid token format in CSV: %v", tokenStr)
+			continue
+		}
+
+		res, err := models.EventVehicles(
+			qm.Where("event_id = ? AND vehicle_token_id = ? AND developer_license_address = ?", webhookID, dec, dl),
+		).DeleteAll(c.Context(), v.store.DBS().Writer)
+		if err != nil {
+			v.logger.Error().Err(err).Msgf("Failed to unsubscribe vehicle from CSV: %v", tokenStr)
+			continue
+		}
+		if res > 0 {
+			count++
+		}
+	}
+
+	return c.JSON(fiber.Map{"message": fmt.Sprintf("Unsubscribed %d vehicles", count)})
 }
 
 // RemoveVehicleFromWebhook godoc


### PR DESCRIPTION
# Proposed Changes
- creates new routes and controller functions that take a CSV as form-data and parses it for vehicle token IDs, and then subscribes or unsubscribes them from a particular webhook

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
- `/v1/webhooks/:webhookId/subscribe/csv`
- `/v1/webhooks/:webhookId/unsubscribe/csv`

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->