### PR TITLE
[ACC-524] add unit to signal response

### DIFF
--- a/internal/controllers/webhook_controller.go
+++ b/internal/controllers/webhook_controller.go
@@ -329,10 +329,20 @@ func (w *WebhookController) GetSignalNames(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to load signals"})
 	}
 
-	signalNames := make([]string, 0)
+	type ValidaSignal struct {
+		Name string `json:"name"`
+		Unit string `json:"unit"`
+	}
+
+	signalNames := make([]ValidaSignal, 0)
 	for _, vssSignal := range vssSignals {
 		if !vssSignal.Deprecated {
-			signalNames = append(signalNames, vssSignal.Name)
+			signal := ValidaSignal{
+				Name: vssSignal.Name,
+				Unit: vssSignal.Unit,
+			}
+
+			signalNames = append(signalNames, signal)
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the `GetSignalNames` method in `webhook_controller.go` to include additional information about signals, specifically their units, in the API response. The most important change is the introduction of a new struct to represent signal data.

### Changes to API response structure:

* [`internal/controllers/webhook_controller.go`](diffhunk://#diff-61c4bb3249e99da7b2123d1da7907490ddd4eb27720f41b9f8e7dd36ea262a56L332-R345): Replaced the `signalNames` slice of strings with a slice of a new struct, `ValidaSignal`, which includes both the `Name` and `Unit` of each signal. This ensures that the API response provides more detailed information about each signal.