### PR TITLE
Use the constructed global logger in the cache

### DIFF
--- a/cmd/vehicle-events-api/main.go
+++ b/cmd/vehicle-events-api/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
 
 	"github.com/rs/zerolog"
 
@@ -100,7 +101,7 @@ func startDeviceSignalsConsumer(ctx context.Context, logger zerolog.Logger, sett
 	}
 
 	// Initialize the in-memory webhook cache.
-	webhookCache := services.NewWebhookCache()
+	webhookCache := services.NewWebhookCache(&logger)
 
 	store := sharedDB.NewDbConnectionFromSettings(ctx, &settings.DB, true)
 	store.WaitForDB(logger)

--- a/cmd/vehicle-events-api/main.go
+++ b/cmd/vehicle-events-api/main.go
@@ -7,11 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/adaptor"
-
-	"github.com/rs/zerolog"
-
 	"github.com/DIMO-Network/shared"
 	sharedDB "github.com/DIMO-Network/shared/db"
 	"github.com/DIMO-Network/vehicle-events-api/internal/api"
@@ -20,7 +15,10 @@ import (
 	"github.com/DIMO-Network/vehicle-events-api/internal/kafka"
 	"github.com/DIMO-Network/vehicle-events-api/internal/services"
 	"github.com/IBM/sarama"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 )
 
 // @title           Vehicle Events API

--- a/internal/services/webhook_cache_test.go
+++ b/internal/services/webhook_cache_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 
 	"github.com/DIMO-Network/vehicle-events-api/internal/utils"
+	"github.com/rs/zerolog"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 )
+
+var nopLogger = zerolog.Nop()
 
 func TestPopulateCache(t *testing.T) {
 	orig := FetchWebhooksFromDBFunc
@@ -24,7 +27,7 @@ func TestPopulateCache(t *testing.T) {
 		}, nil
 	}
 
-	cache := NewWebhookCache()
+	cache := NewWebhookCache(&nopLogger)
 	if err := cache.PopulateCache(context.Background(), nil); err != nil {
 		t.Fatalf("PopulateCache returned error: %v", err)
 	}
@@ -42,14 +45,14 @@ func TestPopulateCache_Error(t *testing.T) {
 		return nil, errors.New("db error")
 	}
 
-	cache := NewWebhookCache()
+	cache := NewWebhookCache(&nopLogger)
 	if err := cache.PopulateCache(context.Background(), nil); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 }
 
 func TestGetWebhooks_Empty(t *testing.T) {
-	cache := NewWebhookCache()
+	cache := NewWebhookCache(&nopLogger)
 	// without PopulateCache, lookup should return nil
 	if got := cache.GetWebhooks(123, "foo"); got != nil {
 		t.Errorf("expected nil slice, got %v", got)
@@ -64,7 +67,7 @@ func TestUpdateAndGetWebhooks(t *testing.T) {
 			},
 		},
 	}
-	cache := NewWebhookCache()
+	cache := NewWebhookCache(&nopLogger)
 	cache.Update(data)
 
 	hooks := cache.GetWebhooks(55, "gps")
@@ -112,7 +115,7 @@ func TestPopulateCacheNormalization(t *testing.T) {
 		return stubData, nil
 	}
 
-	wc := NewWebhookCache()
+	wc := NewWebhookCache(&nopLogger)
 	if err := wc.PopulateCache(context.Background(), nil); err != nil {
 		t.Fatalf("PopulateCache failed: %v", err)
 	}


### PR DESCRIPTION
In particular, the cache will respect the log level set in the settings.

# Proposed Changes

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->