### PR TITLE
fix: remove the ability to change metricName

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -852,10 +852,6 @@ const docTemplate = `{
                     "description": "DisplayName updates the user-friendly unique name per developer license.",
                     "type": "string"
                 },
-                "metricName": {
-                    "description": "MetricName updates the signal/event name used by the webhook.",
-                    "type": "string"
-                },
                 "status": {
                     "description": "Status updates the current state of the webhook (e.g. \"enabled\" or \"Disabled\").",
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -843,10 +843,6 @@
                     "description": "DisplayName updates the user-friendly unique name per developer license.",
                     "type": "string"
                 },
-                "metricName": {
-                    "description": "MetricName updates the signal/event name used by the webhook.",
-                    "type": "string"
-                },
                 "status": {
                     "description": "Status updates the current state of the webhook (e.g. \"enabled\" or \"Disabled\").",
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -110,9 +110,6 @@ definitions:
         description: DisplayName updates the user-friendly unique name per developer
           license.
         type: string
-      metricName:
-        description: MetricName updates the signal/event name used by the webhook.
-        type: string
       status:
         description: Status updates the current state of the webhook (e.g. "enabled"
           or "Disabled").

--- a/internal/controllers/webhook/types.go
+++ b/internal/controllers/webhook/types.go
@@ -39,8 +39,6 @@ type RegisterWebhookResponse struct {
 // UpdateWebhookRequest represents the fields that can be modified on an existing webhook.
 // All fields are optional; only provided fields will be updated.
 type UpdateWebhookRequest struct {
-	// MetricName updates the signal/event name used by the webhook.
-	MetricName *string `json:"metricName"`
 	// Condition updates the CEL expression used to decide when to fire.
 	Condition *string `json:"condition"`
 	// CoolDownPeriod updates the minimum number of seconds between firings.

--- a/internal/controllers/webhook/webhook_controller.go
+++ b/internal/controllers/webhook/webhook_controller.go
@@ -212,12 +212,6 @@ func (w *WebhookController) UpdateWebhook(c *fiber.Ctx) error {
 		}
 	}
 
-	if payload.MetricName != nil {
-		if err := w.validateServiceAndMetricName(event.Service, *payload.MetricName); err != nil {
-			return err
-		}
-		event.MetricName = *payload.MetricName
-	}
 	if payload.TargetURL != nil {
 		if err := validateTargetURL(*payload.TargetURL); err != nil {
 			return err

--- a/internal/controllers/webhook/webhook_controller_test.go
+++ b/internal/controllers/webhook/webhook_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DIMO-Network/model-garage/pkg/vss"
 	"github.com/DIMO-Network/server-garage/pkg/fibercommon"
 	"github.com/DIMO-Network/vehicle-triggers-api/internal/auth"
 	"github.com/DIMO-Network/vehicle-triggers-api/internal/db/models"
@@ -327,9 +326,9 @@ func TestWebhookController_UpdateWebhook(t *testing.T) {
 			FailureCount:   5,
 		}
 
-		newMetricName := vss.FieldPowertrainTransmissionTravelledDistance
+		newCondition := "valueNumber > 60"
 		payload := UpdateWebhookRequest{
-			MetricName: &newMetricName,
+			Condition: &newCondition,
 		}
 
 		mockRepo.EXPECT().
@@ -340,7 +339,7 @@ func TestWebhookController_UpdateWebhook(t *testing.T) {
 		mockRepo.EXPECT().
 			UpdateTrigger(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, trigger *models.Trigger) error {
-				assert.Equal(t, newMetricName, trigger.MetricName)
+				assert.Equal(t, newCondition, trigger.Condition)
 				assert.Equal(t, 0, trigger.FailureCount) // Should be reset
 				return nil
 			}).


### PR DESCRIPTION
Changing the metric Name would also change the permissions needed for a webhook.