### PR TITLE
fix(kafka): wrap subscribe error so underlying cause surfaces

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -63,7 +63,7 @@ func NewConsumer(cfg *Config) (*Consumer, error) {
 func (c *Consumer) Start(ctx context.Context) error {
 	messages, err := c.subscriber.Subscribe(ctx, c.topic)
 	if err != nil {
-		return fmt.Errorf("could not subscribe to topic: %s", c.topic)
+		return fmt.Errorf("could not subscribe to topic %q: %w", c.topic, err)
 	}
 	if c.Processor == nil {
 		return fmt.Errorf("processor function is nil")


### PR DESCRIPTION
## Summary
- Wraps the watermill/sarama error returned from `Subscribe` instead of discarding it. Prior log only contained the topic name (`could not subscribe to topic: topic.device.events`), masking root causes like missing topic or ACL denial.

## Why now
Prod crashloop on `topic.device.events`. Real underlying error is currently invisible — this change makes the next deploy log the actual cause.

## Test plan
- [ ] Tag `v1.4.4` after merge, bump chart, observe real error in prod logs.