### PR TITLE
fix(consumer): eliminate Start/Stop race + add startup diagnostics

### DIFF
--- a/cmd/vehicle-triggers-api/main.go
+++ b/cmd/vehicle-triggers-api/main.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/DIMO-Network/server-garage/pkg/env"
 	"github.com/DIMO-Network/server-garage/pkg/logging"
@@ -79,16 +82,16 @@ func main() {
 
 	monApp := monserver.NewMonitoringServer(&logger, settings.EnablePprof)
 	logger.Info().Str("port", strconv.Itoa(settings.MonPort)).Msgf("Starting monitoring server")
-	runner.RunHandler(runnerCtx, runnerGroup, monApp, net.JoinHostPort("0.0.0.0", strconv.Itoa(settings.MonPort)))
+	runHandlerWithLogging(runnerCtx, runnerGroup, &logger, "monitoring", monApp, net.JoinHostPort("0.0.0.0", strconv.Itoa(settings.MonPort)))
 
 	servers, err := app.CreateServers(runnerCtx, &settings, logger)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to create servers")
 	}
 	logger.Info().Str("port", strconv.Itoa(settings.Port)).Msgf("Starting web server")
-	runner.RunFiber(runnerCtx, runnerGroup, servers.Application, net.JoinHostPort("0.0.0.0", strconv.Itoa(settings.Port)))
-	RunConsumer(runnerCtx, runnerGroup, servers.SignalConsumer)
-	RunConsumer(runnerCtx, runnerGroup, servers.EventConsumer)
+	runFiberWithLogging(runnerCtx, runnerGroup, &logger, servers.Application, net.JoinHostPort("0.0.0.0", strconv.Itoa(settings.Port)))
+	RunConsumer(runnerCtx, runnerGroup, &logger, servers.SignalConsumer)
+	RunConsumer(runnerCtx, runnerGroup, &logger, servers.EventConsumer)
 
 	if err := runnerGroup.Wait(); err != nil {
 		logger.Fatal().Err(err).Msg("Server failed.")
@@ -96,18 +99,77 @@ func main() {
 	logger.Info().Msg("Server stopped.")
 }
 
-// RunFiber starts a Fiber application in a new goroutine and shuts it down when the context is cancelled.
-func RunConsumer(ctx context.Context, group *errgroup.Group, consumer *kafka.Consumer) {
+// RunConsumer starts the Kafka consumer in a single goroutine. Stop is
+// deferred until Start returns so the subscriber cannot be closed before
+// Subscribe runs (which would mask the real Subscribe error as
+// "subscriber closed"). Entry/exit is logged with the consumer's name.
+func RunConsumer(ctx context.Context, group *errgroup.Group, logger *zerolog.Logger, consumer *kafka.Consumer) {
+	name := consumer.Name()
+	topic := consumer.Topic()
 	group.Go(func() error {
-		if err := consumer.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start consumer: %w", err)
+		logger.Info().Str("consumer", name).Str("topic", topic).Msg("consumer goroutine: start enter")
+		err := consumer.Start(ctx)
+		logger.Info().Str("consumer", name).Str("topic", topic).Err(err).Msg("consumer goroutine: start exit")
+
+		stopErr := consumer.Stop(context.Background())
+		logger.Info().Str("consumer", name).Str("topic", topic).Err(stopErr).Msg("consumer goroutine: stop exit")
+
+		if err != nil {
+			return fmt.Errorf("consumer %q (topic %q) start: %w", name, topic, err)
+		}
+		if stopErr != nil {
+			return fmt.Errorf("consumer %q (topic %q) stop: %w", name, topic, stopErr)
+		}
+		return nil
+	})
+}
+
+// runFiberWithLogging mirrors runner.RunFiber but logs goroutine
+// enter/exit so we can see which subsystem returned first.
+func runFiberWithLogging(ctx context.Context, group *errgroup.Group, logger *zerolog.Logger, fiberApp runner.FiberApp, addr string) {
+	group.Go(func() error {
+		logger.Info().Str("addr", addr).Msg("fiber goroutine: listen enter")
+		err := fiberApp.Listen(addr)
+		logger.Info().Str("addr", addr).Err(err).Msg("fiber goroutine: listen exit")
+		if err != nil {
+			return fmt.Errorf("fiber listen %q: %w", addr, err)
 		}
 		return nil
 	})
 	group.Go(func() error {
 		<-ctx.Done()
-		if err := consumer.Stop(ctx); err != nil {
-			return fmt.Errorf("failed to shutdown consumer: %w", err)
+		logger.Info().Str("addr", addr).Msg("fiber goroutine: shutdown enter")
+		err := fiberApp.Shutdown()
+		logger.Info().Str("addr", addr).Err(err).Msg("fiber goroutine: shutdown exit")
+		if err != nil {
+			return fmt.Errorf("fiber shutdown %q: %w", addr, err)
+		}
+		return nil
+	})
+}
+
+// runHandlerWithLogging mirrors runner.RunHandler but logs goroutine
+// enter/exit so we can see which subsystem returned first.
+func runHandlerWithLogging(ctx context.Context, group *errgroup.Group, logger *zerolog.Logger, name string, handler http.Handler, addr string) {
+	srv := &http.Server{Addr: addr, Handler: handler}
+	group.Go(func() error {
+		logger.Info().Str("server", name).Str("addr", addr).Msg("http goroutine: listen enter")
+		err := srv.ListenAndServe()
+		logger.Info().Str("server", name).Str("addr", addr).Err(err).Msg("http goroutine: listen exit")
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("%s listen %q: %w", name, addr, err)
+		}
+		return nil
+	})
+	group.Go(func() error {
+		<-ctx.Done()
+		logger.Info().Str("server", name).Str("addr", addr).Msg("http goroutine: shutdown enter")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		err := srv.Shutdown(shutdownCtx)
+		logger.Info().Str("server", name).Str("addr", addr).Err(err).Msg("http goroutine: shutdown exit")
+		if err != nil {
+			return fmt.Errorf("%s shutdown %q: %w", name, addr, err)
 		}
 		return nil
 	})

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -182,6 +182,7 @@ func createSignalConsumer(ctx context.Context, settings *config.Settings, tokenE
 		GroupID:         "vehicle-triggers",
 		MaxInFlight:     int64(settings.MaxInFlight),
 		Processor:       vehicleProcessor.ProcessSignalMessages,
+		Name:            "signals",
 	}
 
 	consumer, err := kafka.NewConsumer(consumerConfig)
@@ -206,6 +207,7 @@ func createEventConsumer(ctx context.Context, settings *config.Settings, tokenEx
 		GroupID:         "vehicle-triggers",
 		MaxInFlight:     int64(settings.MaxInFlight),
 		Processor:       vehicleProcessor.ProcessEventMessages,
+		Name:            "events",
 	}
 
 	consumer, err := kafka.NewConsumer(consumerConfig)

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	wmkafka "github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/rs/zerolog"
 )
 
 type ProcessorFunc func(ctx context.Context, messages <-chan *message.Message, maxInFlight int) error
@@ -19,14 +20,23 @@ type Config struct {
 	GroupID         string
 	MaxInFlight     int64
 	Processor       ProcessorFunc
+	// Name is a human-readable identifier used in log lines (e.g. "signals", "events").
+	Name string
 }
 
 type Consumer struct {
 	subscriber  *wmkafka.Subscriber
 	topic       string
+	name        string
 	Processor   ProcessorFunc
 	maxInFlight int
 }
+
+// Name returns the consumer's identifier used in log lines.
+func (c *Consumer) Name() string { return c.name }
+
+// Topic returns the topic this consumer subscribes to.
+func (c *Consumer) Topic() string { return c.topic }
 
 func NewConsumer(cfg *Config) (*Consumer, error) {
 	saramaSubscriberConfig := wmkafka.DefaultSaramaSubscriberConfig()
@@ -52,24 +62,36 @@ func NewConsumer(cfg *Config) (*Consumer, error) {
 		maxInFlight = 1
 	}
 
+	name := cfg.Name
+	if name == "" {
+		name = cfg.Topic
+	}
+
 	return &Consumer{
 		subscriber:  subscriber,
 		topic:       cfg.Topic,
+		name:        name,
 		Processor:   cfg.Processor,
 		maxInFlight: maxInFlight,
 	}, nil
 }
 
 func (c *Consumer) Start(ctx context.Context) error {
+	logger := zerolog.Ctx(ctx).With().Str("consumer", c.name).Str("topic", c.topic).Logger()
+	logger.Info().Msg("kafka consumer: subscribing")
 	messages, err := c.subscriber.Subscribe(ctx, c.topic)
 	if err != nil {
+		logger.Error().Err(err).Msg("kafka consumer: subscribe failed")
 		return fmt.Errorf("could not subscribe to topic %q: %w", c.topic, err)
 	}
+	logger.Info().Msg("kafka consumer: subscribed, entering processor")
 	if c.Processor == nil {
 		return fmt.Errorf("processor function is nil")
 	}
 
-	return c.Processor(ctx, messages, c.maxInFlight)
+	err = c.Processor(ctx, messages, c.maxInFlight)
+	logger.Info().Err(err).Msg("kafka consumer: processor returned")
+	return err
 }
 
 func (c *Consumer) Stop(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- The Stop watcher goroutine in \`RunConsumer\` could call \`subscriber.Close()\` (via \`<-ctx.Done()\`) before the Start goroutine reached \`Subscribe()\`. Subscribe then returned \`"subscriber closed"\`, hiding the real upstream error that cancelled \`runnerCtx\`.
- Stop is now deferred inside the same goroutine as Start, so the subscriber cannot be closed before subscribe runs.
- Each consumer is named (\"signals\" / \"events\"). \`Consumer.Start\` logs subscribe / subscribed / processor-returned. \`RunConsumer\`, \`runFiberWithLogging\`, \`runHandlerWithLogging\` all log goroutine enter+exit so the next prod fatal points at the subsystem that actually returned the first error.

## Why now
Prod crashloop on \`topic.device.events\` reported \`"subscriber closed"\`, which is a downstream symptom of the race above, not the real cause. We need the actual first error to diagnose.

## Test plan
- [ ] Build passes.
- [ ] Tag v1.4.5 after merge.
- [ ] Deploy to prod; collect first crash log and read which goroutine returned first.