### PR TITLE
debug(webhookcache): instrument PopulateCache for OOM diagnosis

### DIFF
--- a/internal/services/webhookcache/webhook_cache.go
+++ b/internal/services/webhookcache/webhook_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -55,6 +56,10 @@ func NewWebhookCache(repo Repository, settings *config.Settings) *WebhookCache {
 
 // PopulateCache builds the cache from the database
 func (wc *WebhookCache) PopulateCache(ctx context.Context) error {
+	logger := zerolog.Ctx(ctx)
+	start := time.Now()
+	logMemStats(logger, "populate_cache_enter")
+
 	webhooks, err := wc.fetchVehicleWebhooks(ctx)
 	if err != nil {
 		if errors.Is(err, errNoWebhookConfig) {
@@ -65,7 +70,29 @@ func (wc *WebhookCache) PopulateCache(ctx context.Context) error {
 	}
 
 	wc.Update(webhooks)
+	logger.Info().
+		Int("asset_count", len(webhooks)).
+		Dur("elapsed", time.Since(start)).
+		Msg("webhook cache populated")
+	logMemStats(logger, "populate_cache_exit")
 	return nil
+}
+
+// logMemStats records the current Go heap stats so we can attribute OOMs to a
+// specific startup phase. Cheap: ReadMemStats stops the world briefly but is
+// negligible at startup.
+func logMemStats(logger *zerolog.Logger, phase string) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	logger.Info().
+		Str("phase", phase).
+		Uint64("heap_alloc_mb", m.HeapAlloc>>20).
+		Uint64("heap_sys_mb", m.HeapSys>>20).
+		Uint64("heap_inuse_mb", m.HeapInuse>>20).
+		Uint64("heap_objects", m.HeapObjects).
+		Uint64("sys_mb", m.Sys>>20).
+		Uint32("num_gc", m.NumGC).
+		Msg("memstats")
 }
 
 func (wc *WebhookCache) ScheduleRefresh(ctx context.Context) {
@@ -107,21 +134,30 @@ func (wc *WebhookCache) Update(newData map[string]map[string][]*Webhook) {
 }
 
 func (wc *WebhookCache) fetchVehicleWebhooks(ctx context.Context) (map[string]map[string][]*Webhook, error) {
+	logger := zerolog.Ctx(ctx)
+	fetchStart := time.Now()
 	subs, err := wc.repo.InternalGetAllVehicleSubscriptions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all vehicle subscriptions: %w", err)
 	}
+	logger.Info().
+		Int("sub_count", len(subs)).
+		Dur("fetch_elapsed", time.Since(fetchStart)).
+		Msg("loaded vehicle subscriptions")
+	logMemStats(logger, "after_load_subs")
 
 	// There will be many more vehicle subscriptions than triggers,
 	// so we can share the same trigger object to reduce memory usage and database calls
 	uniqueTriggers := make(map[string]*Webhook)
 
 	newData := make(map[string]map[string][]*Webhook)
-	logger := zerolog.Ctx(ctx)
+	triggerFetchStart := time.Now()
+	triggerFetches := 0
 	for _, sub := range subs {
 		webhook, ok := uniqueTriggers[sub.TriggerID]
 		if !ok {
 			webhook = &Webhook{}
+			triggerFetches++
 			webhook.Trigger, err = wc.repo.InternalGetTriggerByID(ctx, sub.TriggerID)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to get trigger by id for webhook cache")
@@ -149,6 +185,15 @@ func (wc *WebhookCache) fetchVehicleWebhooks(ctx context.Context) (map[string]ma
 		key := webhookKey(webhook.Trigger.Service, webhook.Trigger.MetricName)
 		newData[sub.AssetDid][key] = append(newData[sub.AssetDid][key], webhook)
 	}
+	logger.Info().
+		Int("sub_count", len(subs)).
+		Int("unique_trigger_fetches", triggerFetches).
+		Int("unique_trigger_cache", len(uniqueTriggers)).
+		Int("asset_count", len(newData)).
+		Dur("build_elapsed", time.Since(triggerFetchStart)).
+		Msg("webhook cache build complete")
+	logMemStats(logger, "after_build_cache")
+
 	if len(newData) == 0 {
 		return nil, errNoWebhookConfig
 	}


### PR DESCRIPTION
## Why
Prod is OOMKilled at startup. The earlier "subscriber closed" / "could not subscribe" fatals were downstream symptoms of the pod being SIGKILLed mid-init by the kernel/k8s, then errgroup goroutines racing during teardown.

Suspect: \`WebhookCache.PopulateCache\` loads every row of \`vehicle_subscriptions\` (joined on triggers) via SQLBoiler's \`.All()\` and then makes a per-unique-trigger \`InternalGetTriggerByID\` round-trip in a loop. If the subscriptions table has grown, that slice plus the resulting nested \`map[assetDID]map[key][]*Webhook\` can blow up the heap well before Kafka subscribers even start.

## What this adds
Row counts and \`runtime.MemStats\` snapshots so we can see exactly where the heap explodes:

- \`populate_cache_enter\` — baseline heap before any DB work
- \`after_load_subs\` — heap right after the all-subscriptions \`.All()\` returns, plus \`sub_count\` and fetch elapsed
- \`after_build_cache\` — heap after cache map is built, plus \`unique_trigger_fetches\`, \`asset_count\`, build elapsed
- \`populate_cache_exit\` — final heap with \`asset_count\` and total elapsed

Each memstats line has \`heap_alloc_mb\`, \`heap_sys_mb\`, \`heap_inuse_mb\`, \`heap_objects\`, \`sys_mb\`, \`num_gc\`.

No behavior change — pure logging.

## Test plan
- [x] Unit tests still pass (\`go test ./internal/services/webhookcache/...\`)
- [ ] Tag v1.4.6, deploy, read log line that comes immediately before the OOM kill to see which phase blew the heap