### PR TITLE
fix(cache,chart): parallelize trigger compile + widen probe deadlines

### DIFF
--- a/charts/vehicle-triggers-api/templates/deployment.yaml
+++ b/charts/vehicle-triggers-api/templates/deployment.yaml
@@ -54,19 +54,19 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 180
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 6
             successThreshold: 1
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 5
             timeoutSeconds: 3
-            failureThreshold: 3
+            failureThreshold: 6
             successThreshold: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/internal/services/webhookcache/webhook_cache.go
+++ b/internal/services/webhookcache/webhook_cache.go
@@ -146,33 +146,24 @@ func (wc *WebhookCache) fetchVehicleWebhooks(ctx context.Context) (map[string]ma
 		Msg("loaded vehicle subscriptions")
 	logMemStats(logger, "after_load_subs")
 
-	// There will be many more vehicle subscriptions than triggers,
-	// so we can share the same trigger object to reduce memory usage and database calls
-	uniqueTriggers := make(map[string]*Webhook)
+	// Collect unique trigger IDs first; many subscriptions share triggers.
+	uniqueTriggerIDs := make(map[string]struct{}, len(subs))
+	for _, sub := range subs {
+		uniqueTriggerIDs[sub.TriggerID] = struct{}{}
+	}
+
+	// Fetch + CEL-compile each unique trigger in parallel. Each compile is
+	// CPU-bound (~5ms) and the loop is hot on startup (~10k triggers => 50s
+	// serial). Parallelising across GOMAXPROCS workers brings build_elapsed
+	// well under the kubelet liveness deadline.
+	triggerFetchStart := time.Now()
+	uniqueTriggers := wc.compileTriggersParallel(ctx, uniqueTriggerIDs)
 
 	newData := make(map[string]map[string][]*Webhook)
-	triggerFetchStart := time.Now()
-	triggerFetches := 0
 	for _, sub := range subs {
 		webhook, ok := uniqueTriggers[sub.TriggerID]
 		if !ok {
-			webhook = &Webhook{}
-			triggerFetches++
-			webhook.Trigger, err = wc.repo.InternalGetTriggerByID(ctx, sub.TriggerID)
-			if err != nil {
-				logger.Error().Err(err).Msg("failed to get trigger by id for webhook cache")
-				continue
-			}
-			valueType := ""
-			if triggersrepo.IsSignalService(webhook.Trigger.Service) {
-				valueType = signals.GetSignalDefinitionOrDefault(signals.BareSignalName(webhook.Trigger.MetricName), signals.NumberType).ValueType
-			}
-			webhook.Program, err = celcondition.PrepareCondition(webhook.Trigger.Service, webhook.Trigger.Condition, valueType)
-			if err != nil {
-				logger.Error().Err(err).Str("trigger_id", webhook.Trigger.ID).Msg("failed to prepare condition")
-				continue
-			}
-			uniqueTriggers[sub.TriggerID] = webhook
+			continue
 		}
 		if webhook.Trigger.Status != triggersrepo.StatusEnabled {
 			continue
@@ -187,7 +178,7 @@ func (wc *WebhookCache) fetchVehicleWebhooks(ctx context.Context) (map[string]ma
 	}
 	logger.Info().
 		Int("sub_count", len(subs)).
-		Int("unique_trigger_fetches", triggerFetches).
+		Int("unique_trigger_ids", len(uniqueTriggerIDs)).
 		Int("unique_trigger_cache", len(uniqueTriggers)).
 		Int("asset_count", len(newData)).
 		Dur("build_elapsed", time.Since(triggerFetchStart)).
@@ -202,4 +193,65 @@ func (wc *WebhookCache) fetchVehicleWebhooks(ctx context.Context) (map[string]ma
 
 func webhookKey(service, metricName string) string {
 	return service + ":" + metricName
+}
+
+// compileTriggersParallel fetches and CEL-compiles each unique trigger in
+// parallel. Concurrency is capped at GOMAXPROCS to avoid exhausting the DB
+// connection pool. Triggers that fail to fetch or compile are logged and
+// skipped, mirroring the previous behaviour of the serial loop.
+func (wc *WebhookCache) compileTriggersParallel(ctx context.Context, triggerIDs map[string]struct{}) map[string]*Webhook {
+	logger := zerolog.Ctx(ctx)
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+
+	type result struct {
+		id      string
+		webhook *Webhook
+	}
+
+	ids := make(chan string, len(triggerIDs))
+	for id := range triggerIDs {
+		ids <- id
+	}
+	close(ids)
+
+	results := make(chan result, len(triggerIDs))
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for id := range ids {
+				trigger, err := wc.repo.InternalGetTriggerByID(ctx, id)
+				if err != nil {
+					logger.Error().Err(err).Str("trigger_id", id).Msg("failed to get trigger by id for webhook cache")
+					continue
+				}
+				valueType := ""
+				if triggersrepo.IsSignalService(trigger.Service) {
+					valueType = signals.GetSignalDefinitionOrDefault(signals.BareSignalName(trigger.MetricName), signals.NumberType).ValueType
+				}
+				program, err := celcondition.PrepareCondition(trigger.Service, trigger.Condition, valueType)
+				if err != nil {
+					logger.Error().Err(err).Str("trigger_id", trigger.ID).Msg("failed to prepare condition")
+					continue
+				}
+				results <- result{id: id, webhook: &Webhook{Trigger: trigger, Program: program}}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	out := make(map[string]*Webhook, len(triggerIDs))
+	for r := range results {
+		out[r.id] = r.webhook
+	}
+	return out
 }


### PR DESCRIPTION
## Why
v1.4.7 stopped OOMing (\`heap_alloc_mb=58\` after cache build) but pods still crashloop on \`context canceled\` because cache build took **51,350ms** for ~10k unique triggers. With liveness probe (\`initialDelaySeconds=30\`, \`periodSeconds=10\`, \`failureThreshold=3\`) the kubelet starts killing pods after 60s — fiber hasn't bound to 8080 yet, probe gets connection-refused, pod gets SIGTERM mid-cache-build. Cache eventually finishes, fiber starts and immediately gets \`Shutdown()\`, consumers return \`ctx.Err\`, errgroup fatal.

## What
Two changes shipped together so probes and cache speed move in lockstep.

### \`webhookcache\`: parallelize trigger compile (\`compileTriggersParallel\`)
- Collect unique trigger IDs from the subscriptions slice
- Fan out fetch+compile across \`runtime.GOMAXPROCS(0)\` workers using a buffered channel + a results channel
- Second pass over subs builds the asset map serially (no concurrency on the cache map itself)
- Same observable behaviour, same error logging, but on an 8-core node \`build_elapsed\` should drop ~8x (~6s instead of 51s).

### Chart: widen probe deadlines as belt-and-suspenders
- \`livenessProbe\`: \`initialDelaySeconds\` 30 -> 180, \`failureThreshold\` 3 -> 6
- \`readinessProbe\`: \`initialDelaySeconds\` 15 -> 60, \`failureThreshold\` 3 -> 6

Even if cache regresses (more triggers, slower CEL lib, GC), pods have ~240s of liveness headroom and ~90s of readiness headroom on cold start.

## Test plan
- [x] \`go test -race ./internal/services/webhookcache/... ./internal/celcondition/...\` passes
- [x] \`go build ./cmd/vehicle-triggers-api\` clean
- [ ] Tag v1.4.8, deploy, confirm \`build_elapsed\` is single-digit seconds and no more \`context canceled\` fatal