### PR TITLE
tune(cache): refresh every 5m, expose worker count via CACHE_BUILD_WORKERS

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,9 +154,13 @@ func startWebhookCache(ctx context.Context, settings *config.Settings, tokenExch
 	}
 
 	logger := zerolog.Ctx(ctx)
-	// Periodically refresh the cache so new/updated webhooks show up without a restart
+	// Periodically refresh the cache so new/updated webhooks show up without
+	// a restart. Each refresh re-scans the full subscriptions table and
+	// recompiles every trigger's CEL program, so the interval is set
+	// conservatively; subscription writes go through the API which already
+	// nudges the cache via ScheduleRefresh.
 	go func() {
-		ticker := time.NewTicker(1 * time.Minute)
+		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
 		for range ticker.C {
 			webhookCache.ScheduleRefresh(ctx)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -29,6 +29,12 @@ type Settings struct {
 	MaxInFlight int `env:"MAX_IN_FLIGHT" envDefault:"50"`
 	// CacheDebounceTime wait time betweeen to successive cache refreshes
 	CacheDebounceTime time.Duration `env:"CACHE_DEBOUNCE_TIME"`
+	// CacheBuildWorkers caps the parallelism of the per-trigger fetch+CEL
+	// compile loop in webhookcache.PopulateCache. Each worker takes one DB
+	// roundtrip plus one CEL compile at a time, so it doubles as a DB
+	// connection-pool guard. Defaults to 2 because the prod pod is pinned
+	// to ~1 CPU; raise it on multi-core nodes.
+	CacheBuildWorkers int `env:"CACHE_BUILD_WORKERS" envDefault:"2"`
 
 	DB db.Settings `envPrefix:"DB_"`
 }

--- a/internal/services/webhookcache/webhook_cache.go
+++ b/internal/services/webhookcache/webhook_cache.go
@@ -20,7 +20,10 @@ import (
 
 var errNoWebhookConfig = errors.New("no webhook configurations found in the database")
 
-const defaultCacheDebounceTime = 5 * time.Second
+const (
+	defaultCacheDebounceTime = 5 * time.Second
+	defaultCacheBuildWorkers = 2
+)
 
 type Webhook struct {
 	Trigger *models.Trigger
@@ -34,12 +37,13 @@ type Repository interface {
 
 // WebhookCache is an in-memory map: assetDID -> signal name -> []*models.Trigger.
 type WebhookCache struct {
-	mu          sync.RWMutex
-	webhooks    map[string]map[string][]*Webhook
-	repo        Repository
-	lastRefresh time.Time // last time the cache was refreshed
-	schedule    atomic.Bool
-	debounce    time.Duration
+	mu            sync.RWMutex
+	webhooks      map[string]map[string][]*Webhook
+	repo          Repository
+	lastRefresh   time.Time // last time the cache was refreshed
+	schedule      atomic.Bool
+	debounce      time.Duration
+	buildWorkers  int
 }
 
 func NewWebhookCache(repo Repository, settings *config.Settings) *WebhookCache {
@@ -47,10 +51,15 @@ func NewWebhookCache(repo Repository, settings *config.Settings) *WebhookCache {
 	if debounce == 0 {
 		debounce = defaultCacheDebounceTime
 	}
+	workers := settings.CacheBuildWorkers
+	if workers < 1 {
+		workers = defaultCacheBuildWorkers
+	}
 	return &WebhookCache{
-		webhooks: make(map[string]map[string][]*Webhook),
-		repo:     repo,
-		debounce: debounce,
+		webhooks:     make(map[string]map[string][]*Webhook),
+		repo:         repo,
+		debounce:     debounce,
+		buildWorkers: workers,
 	}
 }
 
@@ -196,15 +205,16 @@ func webhookKey(service, metricName string) string {
 }
 
 // compileTriggersParallel fetches and CEL-compiles each unique trigger in
-// parallel. Concurrency is capped at GOMAXPROCS to avoid exhausting the DB
-// connection pool. Triggers that fail to fetch or compile are logged and
-// skipped, mirroring the previous behaviour of the serial loop.
+// parallel. Worker count comes from CACHE_BUILD_WORKERS so prod can tune it
+// against its CPU limit and DB connection pool. Triggers that fail to fetch
+// or compile are logged and skipped, mirroring the previous behaviour of
+// the serial loop.
 func (wc *WebhookCache) compileTriggersParallel(ctx context.Context, triggerIDs map[string]struct{}) map[string]*Webhook {
 	logger := zerolog.Ctx(ctx)
 
-	workers := runtime.GOMAXPROCS(0)
+	workers := wc.buildWorkers
 	if workers < 1 {
-		workers = 1
+		workers = defaultCacheBuildWorkers
 	}
 
 	type result struct {

--- a/sample.env
+++ b/sample.env
@@ -7,6 +7,11 @@ IDENTITY_API_URL="https://identity-api.dev.dimo.zone/query" # Identity API Graph
 KAFKA_BROKERS="localhost:9092"
 DEVICE_SIGNALS_TOPIC=topic.signals
 
+# Worker count for the parallel webhook-cache compile loop. Each worker
+# takes one DB roundtrip + one CEL compile at a time, so this also caps DB
+# pool usage during startup. Default 2 fits a 1-CPU pod; raise on bigger nodes.
+CACHE_BUILD_WORKERS=2
+
  # Database configuration
 DB_HOST="localhost" # Database host
 DB_PORT="5432" # Database port


### PR DESCRIPTION
## Why
v1.4.8 stopped the crashloop, but prod logs show the cache ticker firing every 60s and each rebuild taking 30-60s of CPU. Two follow-ups:

1. The cache refresh interval was 60s. Each refresh re-scans the whole \`vehicle_subscriptions\` table and recompiles every trigger's CEL program — basically the same work as cold start. With 5 replicas, that's a constant background hum of ~250MB heap churn per pod per minute. Subscription mutations already call \`ScheduleRefresh\` via the API path, so the periodic refresh is a safety net, not a primary path. Bumping to 5m.
2. \`compileTriggersParallel\` used \`runtime.GOMAXPROCS(0)\` for worker count. Prod pods have \`cpu: 1\`, so GOMAXPROCS is 1 and parallelization was a no-op. Expose worker count as \`CACHE_BUILD_WORKERS\` (default 2) so prod can run two workers under one CPU (one waiting on DB, one compiling) without burning the DB pool, and multi-core nodes can raise it.

## Changes
- \`config.Settings.CacheBuildWorkers\` (\`env:\"CACHE_BUILD_WORKERS\" envDefault:\"2\"\`)
- \`WebhookCache.buildWorkers\` plumbed from settings, defaults to 2 when unset/<1
- \`compileTriggersParallel\` uses \`wc.buildWorkers\` instead of GOMAXPROCS
- App ticker: \`1*time.Minute\` -> \`5*time.Minute\`
- \`sample.env\` documents the new var

## Test plan
- [x] \`go test -race ./internal/services/webhookcache/... ./internal/celcondition/...\` passes
- [x] \`go build ./cmd/vehicle-triggers-api\` clean
- [ ] Tag v1.4.9, deploy, observe (a) refresh cadence drops to one populate every 5m and (b) startup \`build_elapsed\` improves with workers=2 vs single-threaded