### PR TITLE
Raise prod CPU limit to 2 and request to 500m to stop CFS throttling

### DIFF
--- a/charts/vehicle-triggers-api/values-prod.yaml
+++ b/charts/vehicle-triggers-api/values-prod.yaml
@@ -41,10 +41,10 @@ ingress:
   tls: []
 resources:
   limits:
-    cpu: 1
+    cpu: 2
     memory: 2048Mi
   requests:
-    cpu: 250m
+    cpu: 500m
     memory: 1024Mi
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Why

Prod pods are being CPU-throttled in 5–35% of enforcement periods, continuously, on every pod (`CPUThrottlingHigh` alerts) — despite averaging only 0.2–0.33 cores against the 1-core limit.

The cause is a burst/limit mismatch, not capacity: Go 1.25's container-aware GOMAXPROCS has a documented floor of 2 (confirmed live: `go_sched_gomaxprocs_threads 2`), so the process can consume CPU at 2× the 1-core quota during bursts, exhausting a 100ms enforcement period's allowance in 50ms and then stalling for the remainder. Each stall lands on in-flight work — webhook HTTP sends and Kafka batches — adding tail latency that feeds both the consumer lag and the spurious webhook failure counts we've been fixing.

## What

- CPU limit 1 → 2: matches GOMAXPROCS so bursts can no longer outrun the quota. Limits don't affect scheduling/bin-packing, so this reserves nothing on the node.
- CPU request 250m → 500m: reflects actual usage (~0.3 cores average) for honest scheduling and CFS share weight.

## Verification

After deploy, the throttle ratio should drop to ~0:

```promql
sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="prod",container="vehicle-triggers-api"}[5m]))
  / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="prod",container="vehicle-triggers-api"}[5m]))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)